### PR TITLE
Issue #7 - fixing update-seals to allow forcing updates when hashes exist

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 twine
+mock

--- a/seal_rookery/__init__.py
+++ b/seal_rookery/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import json
 import os
 
@@ -36,8 +37,8 @@ class _SealRookery(object):
             with open(os.path.join(self.seals_root, 'seals.json'), 'r') as f:
                 return json.load(f)
         except IOError:
-            print 'Seals json missing or not generated yet.a' % (
-            os.path.join(self.seals_root, 'seals.json'))
+            print('Seals json missing or not generated yet.a' % (
+            os.path.join(self.seals_root, 'seals.json')))
             return json.loads('{}')
 
 

--- a/seal_rookery/convert_images.py
+++ b/seal_rookery/convert_images.py
@@ -30,7 +30,7 @@ def set_new_hash(court_id, new_hash):
     seals_data[court_id]['hash'] = new_hash
 
 
-def convert_images(verbose=False):
+def convert_images(verbose=False, forced=False):
     images = os.listdir(ORIG_DIR)
     num_images = len(images)
     num_changed = 0
@@ -48,7 +48,7 @@ def convert_images(verbose=False):
         current_hash = get_hash_from_file(path_to_orig)
         old_hash = get_old_hash(image)
 
-        if current_hash != old_hash:
+        if current_hash != old_hash or forced:
             # Update the hash
             set_new_hash(court_id, current_hash)
 
@@ -84,6 +84,7 @@ def convert_images(verbose=False):
                 num_skipped,
             ))
 
+    return num_changed, num_skipped
 
 def save_new_json():
     """Update the JSON object on disk."""

--- a/seal_rookery/convert_images.py
+++ b/seal_rookery/convert_images.py
@@ -23,7 +23,7 @@ def get_old_hash(img):
 
 def get_hash_from_file(img):
     """Get the hash from the current file"""
-    with open(img, 'r') as f:
+    with open(img, 'rb') as f:
         return hashlib.sha256(f.read()).hexdigest()
 
 

--- a/seal_rookery/convert_images.py
+++ b/seal_rookery/convert_images.py
@@ -47,9 +47,9 @@ def convert_images(verbose=False, forced=False):
     num_skipped = 0
     for i, image in enumerate(images, 1):
         if verbose:
-            sys.stdout.write("\nProcessing: %s" % image)
+            sys.stdout.write(u"\nProcessing: %s" % image)
         else:
-            sys.stdout.write('\rUpdating seals: %s of %s' % (i, num_images))
+            sys.stdout.write(u'\rUpdating seals: %s of %s' % (i, num_images))
             sys.stdout.flush()
         court_id = image.split('.')[0]
         final_name = '%s.png' % court_id
@@ -65,12 +65,14 @@ def convert_images(verbose=False, forced=False):
             # Regenerate the images
             for size in ['128', '256', '512', '1024']:
                 if verbose:
-                    sys.stdout.write("  - Making {size}x{size} image...".format(
+                    sys.stdout.write(u"  - Making {size}x{size} image...".format(
                         size=size
                     ))
                 path_to_output = '%s/%s/%s' % (seals_root, size, final_name)
                 if verbose:
-                    sys.stdout.write('    - writing to %s' % (path_to_output,))
+                    sys.stdout.write(
+                        u'    - writing to %s' % (path_to_output,)
+                    )
                 command = [
                     'convert',
                     '-resize',
@@ -84,12 +86,12 @@ def convert_images(verbose=False, forced=False):
             num_changed += 1
         else:
             if verbose:
-                sys.stdout.write(' - Unchanged hash, moving on.')
+                sys.stdout.write(u' - Unchanged hash, moving on.')
             num_skipped += 1
 
     if not verbose:
         sys.stdout.write(
-            "\nDone:\n  %s seals updated\n  %s seals skipped\n" % (
+            u"\nDone:\n  %s seals updated\n  %s seals skipped\n" % (
                 num_changed,
                 num_skipped,
             ))
@@ -122,11 +124,7 @@ def main(argv=None):
                         action='count',
                         help='turn on verbose seal generation messages')
 
-    if argv:
-        args = parser.parse_args(argv)
-    else:
-        args = parser.parse_args()
-
+    args = parser.parse_args(argv)
     changed, skipped = convert_images(
         verbose=bool(args.v), forced=bool(args.f)
     )

--- a/seal_rookery/convert_images.py
+++ b/seal_rookery/convert_images.py
@@ -97,8 +97,14 @@ def save_new_json():
 
 
 def main(argv=None):
-    convert_images()
+    is_forced, is_verbose = False, False
+    if argv and len(argv) > 0:
+        is_forced = '-f' in argv
+        is_verbose = '-v' in argv
+    changed, skipped = convert_images(verbose=is_verbose, forced=is_forced)
     save_new_json()
+
+    return changed, skipped
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'update-seals = seal_rookery.convert_images:convert_images',
+            'update-seals = seal_rookery.convert_images:main',
         ],
     },
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
+from __future__ import print_function
 import os
-
 import ez_setup
 
 ez_setup.use_setuptools()
@@ -38,9 +38,9 @@ class install_lib(_install_lib):
 
     def run(self):
         _install_lib.run(self)
-        print '==============================================================='
-        print ' Remember, run "update-seals" after install to generate seals!'
-        print '==============================================================='
+        print('==============================================================')
+        print(' Remember, run "update-seals" after install to generate seals!')
+        print('==============================================================')
 
 
 class convert(Command):

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.6",
     "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/test.py
+++ b/test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import unittest
+from mock import patch
+from StringIO import StringIO
 from seal_rookery import convert_images
 
 
@@ -49,6 +51,10 @@ class SealGenerationTest(unittest.TestCase):
         self.assertTrue(self.total_seals > 0)
 
     def test_can_force_regeneration_of_seals(self):
+        """
+        Test we can force image conversions from the originals
+        :return:
+        """
         changed, skipped = convert_images.convert_images()
         self.assertEquals(0, changed, 'Without forcing, nothing changes.')
 
@@ -56,6 +62,33 @@ class SealGenerationTest(unittest.TestCase):
         changed, skipped = convert_images.convert_images(forced=True)
         self.assertEquals(prev_skipped, changed, 'Forcing regens all hashes.')
         self.assertEquals(0, skipped, 'Forcing should skip nothing.')
+
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_convert_images_tool_accepts_args(self, mock_stdout):
+        """
+        Test we can pass command line args to the update-seals script.
+
+        Expected output looks like:
+            Updating seals: 1 of 249
+            ...
+            Updating seals: 249 of 249
+            Done:
+              0 seals updated
+              249 seals skipped
+            (0, 249)
+        :return:
+        """
+        changed, skipped = convert_images.main(argv=['-f',])
+        results = mock_stdout.buflist[-1]
+        self.assertTrue(changed > 0)
+        self.assertTrue(skipped == 0)
+        self.assertTrue(('%s seals updated' % (changed,)) in results)
+        self.assertTrue(('%s seals skipped' % (skipped,)) in results)
+
+        changed, skipped = convert_images.main()
+        results = mock_stdout.buflist[-1]
+        self.assertTrue(('%s seals updated' % (changed,)) in results)
+        self.assertTrue(('%s seals skipped' % (skipped,)) in results)
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -32,5 +32,31 @@ class PackagingTests(unittest.TestCase):
             self.fail('Failed to call convert_images(): %s' % (e,))
 
 
+class SealGenerationTest(unittest.TestCase):
+    """
+    Test the ability to generate seals.
+    """
+
+    def setUp(self):
+        from seal_rookery import seals_data
+        hashes = 0
+        for seal in seals_data:
+            if seals_data[seal]['has_seal']:
+                hashes = hashes + 1
+        self.hashes = hashes
+        self.total_seals = len(seals_data)
+        self.assertTrue(self.hashes > 0)
+        self.assertTrue(self.total_seals > 0)
+
+    def test_can_force_regeneration_of_seals(self):
+        changed, skipped = convert_images.convert_images()
+        self.assertEquals(0, changed, 'Without forcing, nothing changes.')
+
+        prev_skipped = skipped
+        changed, skipped = convert_images.convert_images(forced=True)
+        self.assertEquals(prev_skipped, changed, 'Forcing regens all hashes.')
+        self.assertEquals(0, skipped, 'Forcing should skip nothing.')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -2,12 +2,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 from mock import patch
-
-from sys import version_info
-if version_info[0] < 3:
-    from StringIO import StringIO
-else:
-    from io import StringIO
+from io import StringIO
 
 from seal_rookery import convert_images
 
@@ -85,14 +80,15 @@ class SealGenerationTest(unittest.TestCase):
         :return:
         """
         changed, skipped = convert_images.main(argv=['-f',])
-        results = mock_stdout.buflist[-1]
+        results = mock_stdout.getvalue()
         self.assertTrue(changed > 0)
         self.assertTrue(skipped == 0)
         self.assertTrue(('%s seals updated' % (changed,)) in results)
         self.assertTrue(('%s seals skipped' % (skipped,)) in results)
 
-        changed, skipped = convert_images.main()
-        results = mock_stdout.buflist[-1]
+        mock_stdout.seek(0)
+        changed, skipped = convert_images.main(argv=[])
+        results = mock_stdout.getvalue()
         self.assertTrue(('%s seals updated' % (changed,)) in results)
         self.assertTrue(('%s seals skipped' % (skipped,)) in results)
 

--- a/test.py
+++ b/test.py
@@ -2,7 +2,13 @@
 # -*- coding: utf-8 -*-
 import unittest
 from mock import patch
-from StringIO import StringIO
+
+from sys import version_info
+if version_info[0] < 3:
+    from StringIO import StringIO
+else:
+    from io import StringIO
+
 from seal_rookery import convert_images
 
 
@@ -56,12 +62,12 @@ class SealGenerationTest(unittest.TestCase):
         :return:
         """
         changed, skipped = convert_images.convert_images()
-        self.assertEquals(0, changed, 'Without forcing, nothing changes.')
+        self.assertEqual(0, changed, 'Without forcing, nothing changes.')
 
         prev_skipped = skipped
         changed, skipped = convert_images.convert_images(forced=True)
-        self.assertEquals(prev_skipped, changed, 'Forcing regens all hashes.')
-        self.assertEquals(0, skipped, 'Forcing should skip nothing.')
+        self.assertEqual(prev_skipped, changed, 'Forcing regens all hashes.')
+        self.assertEqual(0, skipped, 'Forcing should skip nothing.')
 
     @patch('sys.stdout', new_callable=StringIO)
     def test_convert_images_tool_accepts_args(self, mock_stdout):


### PR DESCRIPTION
As a fix for Issue #7, I've added support for two new command line arguments:

- `-f` force update of seals even if hashes exist and nothing has changed
- `-v` enable verbose mode

It also uses the `argparse` module, so we get some free command line user help:
```
$ ~/.virtualenvs/seals-py27/bin/update-seals -h
usage: update-seals [-h] [-f] [-v]

optional arguments:
  -h, --help  show this help message and exit
  -f          force seal update or regeneration
  -v          turn on verbose seal generation messages
```

Also, made some minor tweaks to support Python 3 while I was in there. Probably should have made a separate issue for that, but it was pretty trivial. Mostly did it because I was looking into mocking `sys.stdout` and for some reason was compelled.

`python setup.py test` passes using both CPython 2.7 and 3.5 (assuming you have ImageMagick so `convert` can be called).