### PR TITLE
Different fix for Issue #9 that doesn't clobber tests

### DIFF
--- a/seal_rookery/convert_images.py
+++ b/seal_rookery/convert_images.py
@@ -125,13 +125,15 @@ def main(argv=None):
                         help='turn on verbose seal generation messages')
 
     args = parser.parse_args(argv)
-    changed, skipped = convert_images(
-        verbose=bool(args.v), forced=bool(args.f)
-    )
+    try:
+        changed, skipped = convert_images(
+            verbose=bool(args.v), forced=bool(args.f)
+        )
+        save_new_json()
+    except Exception:
+        return 1
 
-    save_new_json()
-
-    return changed, skipped
+    return 0
 
 
 if __name__ == '__main__':

--- a/seal_rookery/convert_images.py
+++ b/seal_rookery/convert_images.py
@@ -129,7 +129,10 @@ def main(argv=None):
             verbose=bool(args.v), forced=bool(args.f)
         )
         save_new_json()
-    except Exception:
+    except Exception as error:
+        # Note: will not catch SystemExit from parser.parse_args
+        print('Failed to update seals!')
+        print(str(error))
         return 1
 
     return 0

--- a/test.py
+++ b/test.py
@@ -111,6 +111,24 @@ class SealGenerationTest(unittest.TestCase):
         self.assertTrue(skipped > 0)
         self.assertEqual(0, return_code)
 
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_bad_command_line_args_raise_systemexit(self, mock_stdout):
+        """test that garbage input raises SystemExit"""
+
+        with self.assertRaises(SystemExit):
+            convert_images.main(argv=['garbage'])
+
+    @patch('sys.stdout', new_callable=StringIO)
+    @patch('seal_rookery.convert_images.convert_images')
+    def test_failure_in_convert_images_returns_non_zero(self, mock_convert, mock_stdout):
+        """
+        Test that any failure in the conversion routine will result in a
+        non-zero return code from the interpreter.
+        """
+        return_code = convert_images.main(argv=[])
+        self.assertEqual(1, return_code)
+        self.assertTrue('Failed to update seals!' in mock_stdout.getvalue())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Had to rework the test logic to match the new approach to returns from the `convert_images.main` function.

The `test_convert_images_tool_accepts_args` test now uses regex to parse out the results from stdout, which I think is fine given that test is supposed to be testing the tooling from the user's point of view. Checks for return code being zero as both executions should be successful. 