### PR TITLE
Multiprocessing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ Deployment
 
    ::
 
-       python setup.py bdist_wheel
+       python setup.py sdist
 
 5. Upload the distribution:
 


### PR DESCRIPTION
I noticed that ```update-seals -f``` is used as an ansible task, and will run each time the VM is provisioned.  This PR will do the same when ```-f``` is passed as an option, but will only execute convert when the target file doesn't exist when not passed.  A meager speedup is accomplished by using multiprocessing.  Also, there is no python 3 compatible version that can be used on PyPI.  While the wheels could possibly work if manually extracted to site packages, this package cannot be installed by pip and work in a python3 environment.  Uploading a new ```sdist``` to pypi would fix that.  I also updated the argument parser a little bit.
