### PR TITLE
chore: Move formatting and linting to Ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,6 @@ updates:
   ignore:
   # Ignore all tooling (it can get old, it's mature enough)
   - dependency-name: selenium
-  - dependency-name: black
-  - dependency-name: pylint
-  - dependency-name: flake8
-  - dependency-name: isort
   - dependency-name: mypy
   - dependency-name: flynt
   # Ignore all patch updates.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,20 +2,16 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 
--   repo: https://github.com/psf/black
-    rev: 25.1.0  # Use the latest stable version
-    hooks:
-    -   id: black
-
--   repo: https://github.com/PyCQA/isort
-    rev: 6.0.0
-    hooks:
-    -   id: isort
-        name: isort (python)
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.8
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,32 @@
-[tool.black]
+[tool.ruff]
 line-length = 79
-include = '''.*\.pyi?$'''
+lint.select = [
+  # flake8-bugbear
+  "B",
+  # flake8-comprehensions
+  "C4",
+  # pycodestyle
+  "E",
+  # Pyflakes errors
+  "F",
+  # isort
+  "I",
+  # flake8-simplify
+  "SIM",
+  # flake8-tidy-imports
+  "TID",
+  # pyupgrade
+  "UP",
+  # Pyflakes warnings
+  "W",
+]
+lint.ignore = [
+  # flake8-bugbear opinionated rules
+  "B9",
+  # line-too-long
+  "E501",
+  # suppressible-exception
+  "SIM105",
+  # if-else-block-instead-of-if-exp
+  "SIM108",
+]

--- a/seal_rookery/__init__.py
+++ b/seal_rookery/__init__.py
@@ -2,7 +2,7 @@ import json
 import os
 
 
-class _SealRookery(object):
+class _SealRookery:
     """
     Wrapper for turning seals information into method-backed properties
     allowing the file system hits to be deferred.
@@ -32,11 +32,10 @@ class _SealRookery(object):
         try:
             with open(
                 os.path.join(self.seals_root, "seals.json"),
-                "r",
                 encoding="utf-8",
             ) as f:
                 return json.load(f)
-        except IOError:
+        except OSError:
             print(
                 f"Seals json missing or not generated yet: {os.path.join(self.seals_root, 'seals.json')}"
             )

--- a/seal_rookery/search.py
+++ b/seal_rookery/search.py
@@ -36,7 +36,7 @@ def seal(court: str, size: SIZES = ImageSizes.MEDIUM) -> Optional[str]:
     :param size: The size of the seal you want a URL for..
     :return A URL to the image.
     """
-    if court not in seals.keys():
+    if court not in seals:
         return None
     if size == ImageSizes.ORIGINAL:
         if glob.glob(f"{ROOT}/seals/orig/{court}.*"):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 URL = "https://github.com/freelawproject/seal-rookery"
-DOWNLOAD_URL = "%s/archive/%s.tar.gz" % (URL, VERSION)
+DOWNLOAD_URL = f"{URL}/archive/{VERSION}.tar.gz"
 
 with open("README.md", encoding="utf-8") as f:
     README = f.read()

--- a/test.py
+++ b/test.py
@@ -19,7 +19,6 @@ class PackagingTests(unittest.TestCase):
 
             self.assertTrue(seals_data["ca1"]["has_seal"])
 
-            # Avoid pylint warning
             self.assertIsNotNone(seals_root)
 
         except ImportError:


### PR DESCRIPTION
Replace Black, isort, and pylint(?) with Ruff.

This is my first pull request towards standardizing all Free Law Project repositories on Ruff. It implements my recommended set of Ruff rules.