### PR TITLE
chore(ci): Remove checkout arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-         format: space-delimited
-         token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install stuff
         run: |
           sudo apt-get update


### PR DESCRIPTION
Copy of https://github.com/freelawproject/judge-pics/pull/36 for this repository. Again the parameters date back to a reset commit, 14cadd0.