### PR TITLE
fix(deps): Raise dependency floors only where CVEs require it, and update pre-commit hooks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,13 +8,15 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v4
+      # requirements-ci.txt needs Python >= 3.10 (see the Pillow note there).
+      # The matrix that used to sit here was never wired into setup-python, so
+      # this job silently ran on whatever the runner defaulted to.
       - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
       - name: Install stuff
         run: |
           sudo apt-get update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.16.5
   hooks:
-    - id: ruff
+    - id: ruff-check
       args: [ --fix ]
     - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     -   id: check-added-large-files
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.11
+  rev: v0.16.5
   hooks:
     - id: ruff
       args: [ --fix ]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
   - Relaxed `python-resize-image` from `==1.1.20` to `>=1.1.20`.
   - `boto3`, `botocore`, `pyvips` and `twine` have no advisories against any
     release and remain unconstrained.
+- Updated the pre-commit hooks (incorporates #42, which pre-commit.ci opened):
+  `pre-commit-hooks` v5.0.0 to v6.0.0 and `ruff-pre-commit` v0.11.11 to
+  v0.16.5. Also renamed the `ruff` hook to `ruff-check`; the newer
+  `ruff-pre-commit` keeps `ruff` only as a legacy alias.
 - The maintainer-only `requirements-ci.txt` can no longer be installed on
   Python 3.9: `Pillow>=12.3.0` is the oldest Pillow with no known CVEs, and it
   requires Python >= 3.10. The library itself is pure standard library and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,21 @@
 
 ## Upcoming Changes
 - Support Python 3.13
+- Raised dependency floors only where needed to purge known vulnerabilities,
+  and left everything else deliberately unconstrained:
+  - Added `setuptools` floors to `[build-system].requires`, which was
+    previously unbounded, to keep CVE-2024-6345, CVE-2025-47273 and
+    CVE-2026-59890 out of the build environment. Build requirements are not
+    recorded in the built wheel, so this imposes nothing on installers.
+  - Relaxed `python-resize-image` from `==1.1.20` to `>=1.1.20`.
+  - `boto3`, `botocore`, `pyvips` and `twine` have no advisories against any
+    release and remain unconstrained.
+- The maintainer-only `requirements-ci.txt` can no longer be installed on
+  Python 3.9: `Pillow>=12.3.0` is the oldest Pillow with no known CVEs, and it
+  requires Python >= 3.10. The library itself is pure standard library and
+  still supports 3.9. The upload workflow now pins Python 3.13 explicitly; it
+  previously carried a `python-version: ["3.9"]` matrix that was never passed
+  to `actions/setup-python`.
 
 ## Current Version
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,10 @@
   - Added `setuptools` floors to `[build-system].requires`, which was
     previously unbounded, to keep CVE-2024-6345, CVE-2025-47273 and
     CVE-2026-59890 out of the build environment. Build requirements are not
-    recorded in the built wheel, so this imposes nothing on installers.
+    recorded in the built wheel, so this does not affect anyone installing
+    seal-rookery from PyPI. It does apply to a source build run with
+    `--no-build-isolation`, which already required setuptools >= 77 for the
+    PEP 639 license metadata; on Python 3.10+ that effective floor becomes 83.
   - Relaxed `python-resize-image` from `==1.1.20` to `>=1.1.20`.
   - `boto3`, `botocore`, `pyvips` and `twine` have no advisories against any
     release and remain unconstrained.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,14 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  # These floors exist only to keep known CVEs out of the build environment.
-  # Build requirements are not recorded in the built wheel, so they impose
-  # nothing on anyone installing seal-rookery.
+  # These floors keep known CVEs out of the build environment. They are not
+  # recorded in the built wheel, so they constrain nobody installing
+  # seal-rookery from PyPI. They do apply to a source build run with
+  # --no-build-isolation, which already needed setuptools >= 77 for the PEP 639
+  # license fields below; on 3.10+ that effective floor moves to 83.
   #
-  # 78.1.1 fixes CVE-2024-6345 and CVE-2025-47273. 83.0.0 additionally fixes
+  # CVE-2024-6345 was fixed in 70.0.0 and CVE-2025-47273 in 78.1.1, so 78.1.1
+  # is the oldest release free of both. 83.0.0 additionally fixes
   # CVE-2026-59890, but it is also the first release to drop Python 3.9, which
   # this project still supports, so it is only required from 3.10 upwards.
   "setuptools>=78.1.1; python_version<'3.10'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,15 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-  "setuptools",
+  # These floors exist only to keep known CVEs out of the build environment.
+  # Build requirements are not recorded in the built wheel, so they impose
+  # nothing on anyone installing seal-rookery.
+  #
+  # 78.1.1 fixes CVE-2024-6345 and CVE-2025-47273. 83.0.0 additionally fixes
+  # CVE-2026-59890, but it is also the first release to drop Python 3.9, which
+  # this project still supports, so it is only required from 3.10 upwards.
+  "setuptools>=78.1.1; python_version<'3.10'",
+  "setuptools>=83; python_version>='3.10'",
 ]
 
 [project]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,14 @@
+# Maintainer-only dependencies for the resize + S3 upload job in
+# seal_rookery/upload_images.py. The installed library imports nothing but the
+# standard library, so none of this is imposed on downstream users.
+#
+# Keep these floors as low as possible; only raise one to purge a known
+# vulnerability. Nothing below other than Pillow currently has any advisory
+# against it, so the rest are deliberately left unconstrained.
 boto3
+# 12.3.0 is the oldest Pillow release with no known CVEs. It is also the first
+# to require Python >= 3.10, so this job cannot run on 3.9. See CHANGES.md.
 Pillow>=12.3.0
 botocore
-python-resize-image==1.1.20
+python-resize-image>=1.1.20
 pyvips>=2.1.16


### PR DESCRIPTION
## What this does

Audits every dependency in the repo against the advisory data PyPI publishes, then raises floors **only** where a known vulnerability requires it, keeping everything else deliberately unconstrained. Also incorporates freelawproject/seal-rookery#42 (the pre-commit.ci autoupdate).

The headline finding: **`seal-rookery` declares no runtime dependencies at all.** `seal_rookery/__init__.py` and `seal_rookery/search.py` import nothing outside the standard library, and `[project]` has no `dependencies` key. Everything in `requirements-ci.txt` / `requirements-dev.txt` exists only for the maintainer-only resize + S3 upload job (`upload_images.py`) and the PyPI publish step. None of it reaches people who `pip install seal-rookery`, so leniency there costs nothing either way.

Of the seven packages involved, only **Pillow** and **setuptools** have any advisories against them at all.

## Changes

| Package | Before | After | Why |
|---|---|---|---|
| `setuptools` (build-system) | *unconstrained* | `>=78.1.1` on py3.9, `>=83` on py3.10+ | Purges CVE-2024-6345, CVE-2025-47273, CVE-2026-59890 |
| `python-resize-image` | `==1.1.20` | `>=1.1.20` | No advisories; an exact pin doesn't belong here |
| `Pillow` | `>=12.3.0` | *unchanged* | Already the lowest CVE-free release |
| `boto3`, `botocore`, `pyvips`, `twine` | *unconstrained / low floor* | *unchanged* | No release of any of them has a known advisory |

The `setuptools` floor is split by an environment marker because 83.0.0 is both the fix for CVE-2026-59890 **and** the first release to drop Python 3.9.

Scope of that floor (corrected after review — the original wording here overstated it): build requirements are not recorded in the built wheel, so this affects nobody installing seal-rookery from PyPI. It *does* apply to a source build run with `--no-build-isolation`. That is a real but narrow change, because `main` already had an effective source-build floor of setuptools **77** — the PEP 639 `license = "Unlicense"` / `license-files` fields fail schema validation on 76.1.0 and earlier. So the window moves 77 → 83 on Python 3.10+, rather than appearing from nothing.

Also pins the upload workflow to Python 3.13 — see below.

## Incorporating #42 (pre-commit autoupdate)

Cherry-picked `b87cc87` from `pre-commit-ci-update-config` with the bot's authorship preserved, so #42 can be closed as included here:

- `pre-commit-hooks` v5.0.0 → v6.0.0
- `ruff-pre-commit` v0.11.11 → v0.16.5

#42's only failing check was **Check Changelog Action** — a bot PR can't add a `CHANGES.md` entry. This branch touches `CHANGES.md` anyway, so the entry is added and that check now passes. Everything else on #42 was already green, so the hook bump was known-safe before I pulled it in.

One follow-through on top of the bump: v0.16.5 renamed the `ruff` hook to `ruff-check` and keeps `ruff` only as a legacy alias — the hook literally reported itself as `ruff (legacy alias)` after the bump. Renamed it to `ruff-check` in a separate commit so the bot's cherry-pick stays untouched. pre-commit.ci autoupdate only rewrites `rev:` lines, so this won't fight future autoupdates.

## Weird problems worth flagging

1. **`requirements-ci.txt` cannot be installed on Python 3.9.** `Pillow>=12.3.0` is the *only* Pillow release with no known CVEs (a batch of 2026 advisories landed against 12.2.0 and earlier), and it requires Python >= 3.10. So the floor can't be lowered, and the CI requirements now have a hard 3.10 floor while `requires-python` says `>=3.9`. The library itself is unaffected — it's pure stdlib and still works on 3.9.

2. **The upload workflow's Python matrix was dead config.** `build.yml` declared `python-version: ["3.9"]` but never passed it to `actions/setup-python`, so the job silently ran on whatever the runner defaulted to. That accident is the only reason problem #1 hasn't already broken releases. Wiring the matrix up as written would have broken the job immediately, so this pins 3.13 explicitly instead.

3. **On Python 3.9 there is no CVE-free setuptools.** CVE-2026-59890 is fixed only in 83.0.0+, which requires 3.10. The marker gets 3.9 as close as it can (78.1.1). The residual issue is a macOS-only `MANIFEST.in` exclusion bypass when building an sdist, so it's low-impact for Linux CI — but it is a genuine, unpurgeable residual as long as 3.9 is supported.

4. **Dropping Python 3.9 would collapse #1–#3 into nothing.** 3.9 went EOL in October 2025. I did *not* do this — it changes the library's supported range, which is the opposite of lenient for downstream users, and it's your call, not mine.

5. **Unconstrained `boto3`/`botocore`/`twine` have no effective floor.** Under `--resolution lowest-direct` they resolve to `boto3==0.0.1`, `botocore==0.68.0`, `twine==1.0.1`, none of which would actually run `upload_images.py`. It doesn't bite in practice (CI installs latest), and it isn't a security issue, so I left it alone rather than raising floors you didn't ask for.

6. **`python-resize-image` is abandoned** (last release November 2021) and pulls in `Pillow>=5.1.0` and `requests>=2.19.1`. I verified it still works against Pillow 12.3.0 — `resize_cover`, `resize_width` and `resize_height` all pass — so there's no urgency, but it's a single point of failure whenever Pillow next removes something.

7. Minor: `[project].classifiers` stops at Python 3.12, but tox and `tests.yml` both cover 3.13. Not touched.

## Testing

- `pip-audit --vulnerability-service pypi` on `requirements-ci.txt` + `requirements-dev.txt`: **no known vulnerabilities**, both as CI resolves them and at the new `--resolution lowest-direct` floors.
- `pip-audit` on the build requirements at both marker branches: clean at `setuptools==83.0.0`; the one documented residual at `setuptools==78.1.1` (py3.9) described in #3.
- Verified the markers resolve as intended: py3.9 → 78.1.1, py3.10 → 83.0.0, py3.13 → 83.0.0.
- Measured the pre-existing source-build floor by installing the sdist with `--no-build-isolation` against the unconstrained `requires` from `main`: fails on setuptools 75.3.4 and 76.1.0, builds on 77.0.1 and 80.9.0.
- `pre-commit run --all-files` with the updated hooks: all six pass (`trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-added-large-files`, `ruff-check`, `ruff-format`). Confirmed `ruff-check` is a real hook id in `ruff-pre-commit` v0.16.5, not just the alias.
- `uv build --python 3.9` succeeds (sdist + wheel), confirming the marker doesn't break the 3.9 build env that tox's `.pkg` env uses. CI's `build (3.9)` job agrees.
- `python -m unittest` passes on 3.9 and 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRD2i7C5ukZzVoVDU1L8Qg